### PR TITLE
Convert to ES6 Class, Update package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ['react', 'es2015']
+  "presets": ["react", "es2015"],
+  "plugins": ["transform-class-properties"]
 }

--- a/dist/ReactCropperJS.js
+++ b/dist/ReactCropperJS.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -14,309 +16,312 @@ var _cropperjs2 = _interopRequireDefault(_cropperjs);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ReactCropperJS = _react2.default.createClass({
-  displayName: 'ReactCropperJS',
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
 
-  propTypes: {
-    // DDM react cropperJS options
-    alt: _react2.default.PropTypes.string,
-    crossOrigin: _react2.default.PropTypes.string,
-    src: _react2.default.PropTypes.string.isRequired,
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-    // CropperJS options
-    aspectRatio: _react2.default.PropTypes.number,
-    autoCrop: _react2.default.PropTypes.bool,
-    autoCropArea: _react2.default.PropTypes.number,
-    background: _react2.default.PropTypes.bool,
-    center: _react2.default.PropTypes.bool,
-    checkCrossOrigin: _react2.default.PropTypes.bool,
-    checkOrientation: _react2.default.PropTypes.bool,
-    cropBoxMovable: _react2.default.PropTypes.bool,
-    cropBoxResizable: _react2.default.PropTypes.bool,
-    guides: _react2.default.PropTypes.bool,
-    highlight: _react2.default.PropTypes.bool,
-    minCanvasHeight: _react2.default.PropTypes.number,
-    minCanvasWidth: _react2.default.PropTypes.number,
-    minContainerHeight: _react2.default.PropTypes.number,
-    minContainerWidth: _react2.default.PropTypes.number,
-    minCropBoxHeight: _react2.default.PropTypes.number,
-    minCropBoxWidth: _react2.default.PropTypes.number,
-    modal: _react2.default.PropTypes.bool,
-    movable: _react2.default.PropTypes.bool,
-    preview: _react2.default.PropTypes.string,
-    restore: _react2.default.PropTypes.bool,
-    responsive: _react2.default.PropTypes.bool,
-    rotatable: _react2.default.PropTypes.bool,
-    scalable: _react2.default.PropTypes.bool,
-    toggleDragModeOnDblclick: _react2.default.PropTypes.bool,
-    viewMode: _react2.default.PropTypes.oneOf([0, 1, 2, 3]),
-    wheelZoomRation: _react2.default.PropTypes.number,
-    zoomable: _react2.default.PropTypes.bool,
-    zoomOnTouch: _react2.default.PropTypes.bool,
-    zoomOnWheel: _react2.default.PropTypes.bool,
+var ReactCropperJS = function (_Component) {
+  _inherits(ReactCropperJS, _Component);
 
-    // CropperJS event callbacks
-    crop: _react2.default.PropTypes.func,
-    cropend: _react2.default.PropTypes.func,
-    cropmove: _react2.default.PropTypes.func,
-    cropstart: _react2.default.PropTypes.func,
-    ready: _react2.default.PropTypes.func,
-    zoom: _react2.default.PropTypes.func,
+  function ReactCropperJS() {
+    var _ref;
 
-    // Variable props
-    canvasData: _react2.default.PropTypes.shape({
-      left: _react2.default.PropTypes.number,
-      top: _react2.default.PropTypes.number,
-      width: _react2.default.PropTypes.number,
-      height: _react2.default.PropTypes.number
-    }),
-    cropBoxData: _react2.default.PropTypes.shape({
-      left: _react2.default.PropTypes.number,
-      top: _react2.default.PropTypes.number,
-      width: _react2.default.PropTypes.number,
-      height: _react2.default.PropTypes.number
-    }),
-    data: _react2.default.PropTypes.shape({
-      x: _react2.default.PropTypes.number,
-      y: _react2.default.PropTypes.number,
-      width: _react2.default.PropTypes.number,
-      height: _react2.default.PropTypes.number,
-      rotate: _react2.default.PropTypes.number,
-      scaleX: _react2.default.PropTypes.number,
-      scaleY: _react2.default.PropTypes.number
-    }),
-    dragMode: _react2.default.PropTypes.oneOf(['crop', 'move', 'none']),
-    enable: _react2.default.PropTypes.bool,
-    moveTo: _react2.default.PropTypes.arrayOf(_react2.default.PropTypes.number),
-    rotateTo: _react2.default.PropTypes.number,
-    scaleX: _react2.default.PropTypes.number,
-    scaleY: _react2.default.PropTypes.number,
-    style: _react2.default.PropTypes.object,
-    zoomTo: _react2.default.PropTypes.number,
+    var _temp, _this, _ret;
 
-    // Type of image and the quality of the image to return as a data URL
-    imgType: _react2.default.PropTypes.string,
-    imgQuality: _react2.default.PropTypes.number
-  },
+    _classCallCheck(this, ReactCropperJS);
 
-  getDefaultProps: function getDefaultProps() {
-    return {
-      alt: '',
-      canvasData: null,
-      cropBoxData: null,
-      crossOrigin: null,
-      data: null,
-      dragMode: 'crop',
-      enable: true,
-      imgType: 'image/jpeg',
-      imgQuality: 0.92,
-      rotateTo: 0,
-      scaleX: 1,
-      scaleY: 1,
-      src: null,
-      style: null,
-      zoomTo: 1
-    };
-  },
-  componentDidMount: function componentDidMount() {
-    var options = {},
-        prop = void 0;
-    for (prop in this.props) {
-      if (prop !== 'src' && prop !== 'alt' && prop !== 'crossOrigin') {
-        var propValue = this.props[prop];
-
-        if (typeof this.props[prop] === 'function' && this.hasOwnProperty(prop)) {
-          propValue = this[prop];
-        }
-
-        options[prop] = propValue;
-      }
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
     }
 
-    this.cropper = new _cropperjs2.default(this.refs.img, options);
-  },
-  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-    if (nextProps.src !== this.props.src) {
-      this.cropper.reset().clear().replace(nextProps.src);
-    }
-
-    if (nextProps.aspectRatio !== this.props.aspectRatio) {
-      this.setAspectRatio(nextProps.aspectRatio);
-    }
-
-    if (nextProps.data !== this.props.data) {
-      this.setData(nextProps.data);
-    }
-
-    if (nextProps.dragMode !== this.props.dragMode) {
-      this.setDragMode(nextProps.dragMode);
-    }
-
-    if (nextProps.cropBoxData !== this.props.cropBoxData) {
-      this.setCropBoxData(nextProps.cropBoxData);
-    }
-
-    if (nextProps.canvasData !== this.props.canvasData) {
-      this.setCanvasData(nextProps.canvasData);
-    }
-
-    if (nextProps.moveTo !== this.props.moveTo) {
-      if (nextProps.moveTo.length > 1) {
-        this.moveTo(nextProps.moveTo[0], nextProps.moveTo[1]);
-      } else {
-        this.moveTo(nextProps.moveTo[0]);
-      }
-    }
-
-    if (nextProps.zoomTo !== this.props.zoomTo) {
-      this.zoomTo(nextProps.zoomTo);
-    }
-
-    if (nextProps.rotateTo !== this.props.rotateTo) {
-      this.rotateTo(nextProps.rotateTo);
-    }
-
-    if (nextProps.scaleX !== this.props.scaleX) {
-      this.scaleX(nextProps.scaleX);
-    }
-
-    if (nextProps.scaleY !== this.props.scaleY) {
-      this.scaleY(nextProps.scaleY);
-    }
-
-    if (nextProps.enable !== this.props.enable) {
-      if (nextProps.enable) {
-        this.enable();
-      } else {
-        this.disable();
-      }
-    }
-  },
-  componentWillUnmount: function componentWillUnmount() {
-    if (this.cropper) {
-      // Destroy the cropper, this makes sure events
-      // such as resize are cleaned up and do not leak
-      this.cropper.destroy();
-    }
-  },
-  getCroppedImgDataURL: function getCroppedImgDataURL() {
-    return this.getCroppedCanvas().toDataURL(this.props.imgType, this.props.imgQuality);
-  },
-
-
-  // Event handlers
-  crop: function crop(event) {
-    this.props.crop(event, this.getCroppedImgDataURL());
-  },
-  cropend: function cropend(event) {
-    this.props.cropend(event, this.getCroppedImgDataURL());
-  },
-  cropmove: function cropmove(event) {
-    this.props.cropmove(event, this.getCroppedImgDataURL());
-  },
-  cropstart: function cropstart(event) {
-    this.props.cropstart(event, this.getCroppedImgDataURL());
-  },
-  ready: function ready(event) {
-    this.props.ready(event, this.getCroppedImgDataURL());
-  },
-  zoom: function zoom(event) {
-    this.props.zoom(event, this.getCroppedImgDataURL());
-  },
-
-
-  // CropperJS wrapped functions
-  move: function move(offsetX, offsetY) {
-    return this.cropper.move(offsetX, offsetY);
-  },
-  moveTo: function moveTo(x, y) {
-    return this.cropper.moveTo(x, y);
-  },
-  zoomTo: function zoomTo(ratio) {
-    return this.cropper.zoomTo(ratio);
-  },
-  rotate: function rotate(degree) {
-    return this.cropper.rotate(degree);
-  },
-  rotateTo: function rotateTo(degree) {
-    return this.cropper.rotateTo(degree);
-  },
-  enable: function enable() {
-    return this.cropper.enable();
-  },
-  disable: function disable() {
-    return this.cropper.disable();
-  },
-  reset: function reset() {
-    return this.cropper.reset();
-  },
-  clear: function clear() {
-    return this.cropper.clear();
-  },
-  replace: function replace(url) {
-    return this.cropper.replace(url);
-  },
-  scaleX: function scaleX(_scaleX) {
-    return this.cropper.scaleX(_scaleX);
-  },
-  scaleY: function scaleY(_scaleY) {
-    return this.cropper.scaleY(_scaleY);
-  },
-  getData: function getData(rounded) {
-    return this.cropper.getData(rounded);
-  },
-  setData: function setData(data) {
-    return this.cropper.setData(data);
-  },
-  getContainerData: function getContainerData() {
-    return this.cropper.getContainerData();
-  },
-  getImageData: function getImageData() {
-    return this.cropper.getImageData();
-  },
-  getCanvasData: function getCanvasData() {
-    return this.cropper.getCanvasData();
-  },
-  setCanvasData: function setCanvasData(data) {
-    return this.cropper.setCanvasData(data);
-  },
-  getCropBoxData: function getCropBoxData() {
-    return this.cropper.getCropBoxData();
-  },
-  setCropBoxData: function setCropBoxData(data) {
-    return this.cropper.setCropBoxData(data);
-  },
-  getCroppedCanvas: function getCroppedCanvas(options) {
-    return this.cropper.getCroppedCanvas(options);
-  },
-  setAspectRatio: function setAspectRatio(aspectRatio) {
-    return this.cropper.setAspectRatio(aspectRatio);
-  },
-  setDragMode: function setDragMode(dragMode) {
-    return this.cropper.setDragMode(dragMode);
-  },
-  render: function render() {
-    var imgStyle = {
-      opacity: 0
-    };
-    return _react2.default.createElement(
-      'div',
-      {
-        src: null,
-        crossOrigin: null,
-        alt: null,
-        style: this.props.style
-      },
-      _react2.default.createElement('img', {
-        crossOrigin: this.props.crossOrigin,
-        ref: 'img',
-        src: this.props.src,
-        alt: this.props.alt,
-        style: imgStyle
-      })
-    );
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = ReactCropperJS.__proto__ || Object.getPrototypeOf(ReactCropperJS)).call.apply(_ref, [this].concat(args))), _this), _this.crop = function (event) {
+      _this.props.crop(event, _this.getCroppedImgDataURL());
+    }, _this.cropend = function (event) {
+      _this.props.cropend(event, _this.getCroppedImgDataURL());
+    }, _this.cropmove = function (event) {
+      _this.props.cropmove(event, _this.getCroppedImgDataURL());
+    }, _this.cropstart = function (event) {
+      _this.props.cropstart(event, _this.getCroppedImgDataURL());
+    }, _this.ready = function (event) {
+      _this.props.ready(event, _this.getCroppedImgDataURL());
+    }, _this.zoom = function (event) {
+      _this.props.zoom(event, _this.getCroppedImgDataURL());
+    }, _this.moveTo = function (x, y) {
+      return _this.cropper.moveTo(x, y);
+    }, _this.zoomTo = function (ratio) {
+      return _this.cropper.zoomTo(ratio);
+    }, _this.rotate = function (degree) {
+      return _this.cropper.rotate(degree);
+    }, _this.rotateTo = function (degree) {
+      return _this.cropper.rotateTo(degree);
+    }, _this.enable = function () {
+      return _this.cropper.enable();
+    }, _this.disable = function () {
+      return _this.cropper.disable();
+    }, _this.reset = function () {
+      return _this.cropper.reset();
+    }, _this.clear = function () {
+      return _this.cropper.clear();
+    }, _this.replace = function (url) {
+      return _this.cropper.replace(url);
+    }, _this.scaleX = function (scaleX) {
+      return _this.cropper.scaleX(scaleX);
+    }, _this.scaleY = function (scaleY) {
+      return _this.cropper.scaleY(scaleY);
+    }, _this.getData = function (rounded) {
+      return _this.cropper.getData(rounded);
+    }, _this.setData = function (data) {
+      return _this.cropper.setData(data);
+    }, _this.getContainerData = function () {
+      return _this.cropper.getContainerData();
+    }, _this.getImageData = function () {
+      return _this.cropper.getImageData();
+    }, _this.getCanvasData = function () {
+      return _this.cropper.getCanvasData();
+    }, _this.setCanvasData = function (data) {
+      return _this.cropper.setCanvasData(data);
+    }, _this.getCropBoxData = function () {
+      return _this.cropper.getCropBoxData();
+    }, _this.setCropBoxData = function (data) {
+      return _this.cropper.setCropBoxData(data);
+    }, _this.getCroppedCanvas = function (options) {
+      return _this.cropper.getCroppedCanvas(options);
+    }, _this.setAspectRatio = function (aspectRatio) {
+      return _this.cropper.setAspectRatio(aspectRatio);
+    }, _this.setDragMode = function (dragMode) {
+      return _this.cropper.setDragMode(dragMode);
+    }, _temp), _possibleConstructorReturn(_this, _ret);
   }
-});
 
+  _createClass(ReactCropperJS, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      var options = {},
+          prop = void 0;
+      for (prop in this.props) {
+        if (prop !== 'src' && prop !== 'alt' && prop !== 'crossOrigin') {
+          var propValue = this.props[prop];
+
+          if (typeof this.props[prop] === 'function' && this.hasOwnProperty(prop)) {
+            propValue = this[prop];
+          }
+
+          options[prop] = propValue;
+        }
+      }
+
+      this.cropper = new _cropperjs2.default(this.refs.img, options);
+    }
+  }, {
+    key: 'componentWillReceiveProps',
+    value: function componentWillReceiveProps(nextProps) {
+      if (nextProps.src !== this.props.src) {
+        this.cropper.reset().clear().replace(nextProps.src);
+      }
+
+      if (nextProps.aspectRatio !== this.props.aspectRatio) {
+        this.setAspectRatio(nextProps.aspectRatio);
+      }
+
+      if (nextProps.data !== this.props.data) {
+        this.setData(nextProps.data);
+      }
+
+      if (nextProps.dragMode !== this.props.dragMode) {
+        this.setDragMode(nextProps.dragMode);
+      }
+
+      if (nextProps.cropBoxData !== this.props.cropBoxData) {
+        this.setCropBoxData(nextProps.cropBoxData);
+      }
+
+      if (nextProps.canvasData !== this.props.canvasData) {
+        this.setCanvasData(nextProps.canvasData);
+      }
+
+      if (nextProps.moveTo !== this.props.moveTo) {
+        if (nextProps.moveTo.length > 1) {
+          this.moveTo(nextProps.moveTo[0], nextProps.moveTo[1]);
+        } else {
+          this.moveTo(nextProps.moveTo[0]);
+        }
+      }
+
+      if (nextProps.zoomTo !== this.props.zoomTo) {
+        this.zoomTo(nextProps.zoomTo);
+      }
+
+      if (nextProps.rotateTo !== this.props.rotateTo) {
+        this.rotateTo(nextProps.rotateTo);
+      }
+
+      if (nextProps.scaleX !== this.props.scaleX) {
+        this.scaleX(nextProps.scaleX);
+      }
+
+      if (nextProps.scaleY !== this.props.scaleY) {
+        this.scaleY(nextProps.scaleY);
+      }
+
+      if (nextProps.enable !== this.props.enable) {
+        if (nextProps.enable) {
+          this.enable();
+        } else {
+          this.disable();
+        }
+      }
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      if (this.cropper) {
+        // Destroy the cropper, this makes sure events
+        // such as resize are cleaned up and do not leak
+        this.cropper.destroy();
+      }
+    }
+  }, {
+    key: 'getCroppedImgDataURL',
+    value: function getCroppedImgDataURL() {
+      return this.getCroppedCanvas().toDataURL(this.props.imgType, this.props.imgQuality);
+    }
+
+    // Event handlers
+
+  }, {
+    key: 'move',
+
+
+    // CropperJS wrapped functions
+    value: function move(offsetX, offsetY) {
+      return this.cropper.move(offsetX, offsetY);
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var imgStyle = {
+        opacity: 0
+      };
+      return _react2.default.createElement(
+        'div',
+        {
+          src: null,
+          crossOrigin: null,
+          alt: null,
+          style: this.props.style
+        },
+        _react2.default.createElement('img', {
+          crossOrigin: this.props.crossOrigin,
+          ref: 'img',
+          src: this.props.src,
+          alt: this.props.alt,
+          style: imgStyle
+        })
+      );
+    }
+  }]);
+
+  return ReactCropperJS;
+}(_react.Component);
+
+ReactCropperJS.propTypes = {
+  // DDM react cropperJS options
+  alt: _react.PropTypes.string,
+  crossOrigin: _react.PropTypes.string,
+  src: _react.PropTypes.string.isRequired,
+
+  // CropperJS options
+  aspectRatio: _react.PropTypes.number,
+  autoCrop: _react.PropTypes.bool,
+  autoCropArea: _react.PropTypes.number,
+  background: _react.PropTypes.bool,
+  center: _react.PropTypes.bool,
+  checkCrossOrigin: _react.PropTypes.bool,
+  checkOrientation: _react.PropTypes.bool,
+  cropBoxMovable: _react.PropTypes.bool,
+  cropBoxResizable: _react.PropTypes.bool,
+  guides: _react.PropTypes.bool,
+  highlight: _react.PropTypes.bool,
+  minCanvasHeight: _react.PropTypes.number,
+  minCanvasWidth: _react.PropTypes.number,
+  minContainerHeight: _react.PropTypes.number,
+  minContainerWidth: _react.PropTypes.number,
+  minCropBoxHeight: _react.PropTypes.number,
+  minCropBoxWidth: _react.PropTypes.number,
+  modal: _react.PropTypes.bool,
+  movable: _react.PropTypes.bool,
+  preview: _react.PropTypes.string,
+  restore: _react.PropTypes.bool,
+  responsive: _react.PropTypes.bool,
+  rotatable: _react.PropTypes.bool,
+  scalable: _react.PropTypes.bool,
+  toggleDragModeOnDblclick: _react.PropTypes.bool,
+  viewMode: _react.PropTypes.oneOf([0, 1, 2, 3]),
+  wheelZoomRation: _react.PropTypes.number,
+  zoomable: _react.PropTypes.bool,
+  zoomOnTouch: _react.PropTypes.bool,
+  zoomOnWheel: _react.PropTypes.bool,
+
+  // CropperJS event callbacks
+  crop: _react.PropTypes.func,
+  cropend: _react.PropTypes.func,
+  cropmove: _react.PropTypes.func,
+  cropstart: _react.PropTypes.func,
+  ready: _react.PropTypes.func,
+  zoom: _react.PropTypes.func,
+
+  // Variable props
+  canvasData: _react.PropTypes.shape({
+    left: _react.PropTypes.number,
+    top: _react.PropTypes.number,
+    width: _react.PropTypes.number,
+    height: _react.PropTypes.number
+  }),
+  cropBoxData: _react.PropTypes.shape({
+    left: _react.PropTypes.number,
+    top: _react.PropTypes.number,
+    width: _react.PropTypes.number,
+    height: _react.PropTypes.number
+  }),
+  data: _react.PropTypes.shape({
+    x: _react.PropTypes.number,
+    y: _react.PropTypes.number,
+    width: _react.PropTypes.number,
+    height: _react.PropTypes.number,
+    rotate: _react.PropTypes.number,
+    scaleX: _react.PropTypes.number,
+    scaleY: _react.PropTypes.number
+  }),
+  dragMode: _react.PropTypes.oneOf(['crop', 'move', 'none']),
+  enable: _react.PropTypes.bool,
+  moveTo: _react.PropTypes.arrayOf(_react.PropTypes.number),
+  rotateTo: _react.PropTypes.number,
+  scaleX: _react.PropTypes.number,
+  scaleY: _react.PropTypes.number,
+  style: _react.PropTypes.object,
+  zoomTo: _react.PropTypes.number,
+
+  // Type of image and the quality of the image to return as a data URL
+  imgType: _react.PropTypes.string,
+  imgQuality: _react.PropTypes.number
+};
+ReactCropperJS.defaultProps = {
+  alt: '',
+  canvasData: null,
+  cropBoxData: null,
+  crossOrigin: null,
+  data: null,
+  dragMode: 'crop',
+  enable: true,
+  imgType: 'image/jpeg',
+  imgQuality: 0.92,
+  rotateTo: 0,
+  scaleX: 1,
+  scaleY: 1,
+  src: null,
+  style: null,
+  zoomTo: 1
+};
 exports.default = ReactCropperJS;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "React wrapper around the CropperJS library",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deseretdigital-ui/ddm-react-cropperjs.git"
+  },
   "scripts": {
     "build": "npm run build-js; npm run build-example",
     "build-example": "webpack --config example/webpack.config.js",
@@ -17,7 +21,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "classnames": "^2.2.0",
     "cropperjs": "^0.8.1"
   },
   "devDependencies": {
@@ -27,6 +30,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
+    "babel-plugin-transform-class-properties": "^6.18.0",
     "css-loader": "^0.23.1",
     "eslint": "^2.0",
     "eslint-plugin-react": "^5.0",

--- a/src/ReactCropperJS.jsx
+++ b/src/ReactCropperJS.jsx
@@ -1,109 +1,107 @@
-import React from 'react';
+import React, {Component, PropTypes} from 'react';
 import Cropper from 'cropperjs';
 
-const ReactCropperJS = React.createClass({
+class ReactCropperJS extends Component {
 
-  propTypes: {
+  static propTypes = {
     // DDM react cropperJS options
-    alt: React.PropTypes.string,
-    crossOrigin: React.PropTypes.string,
-    src: React.PropTypes.string.isRequired,
+    alt: PropTypes.string,
+    crossOrigin: PropTypes.string,
+    src: PropTypes.string.isRequired,
 
     // CropperJS options
-    aspectRatio: React.PropTypes.number,
-    autoCrop: React.PropTypes.bool,
-    autoCropArea: React.PropTypes.number,
-    background: React.PropTypes.bool,
-    center: React.PropTypes.bool,
-    checkCrossOrigin: React.PropTypes.bool,
-    checkOrientation: React.PropTypes.bool,
-    cropBoxMovable: React.PropTypes.bool,
-    cropBoxResizable: React.PropTypes.bool,
-    guides: React.PropTypes.bool,
-    highlight: React.PropTypes.bool,
-    minCanvasHeight: React.PropTypes.number,
-    minCanvasWidth: React.PropTypes.number,
-    minContainerHeight: React.PropTypes.number,
-    minContainerWidth: React.PropTypes.number,
-    minCropBoxHeight: React.PropTypes.number,
-    minCropBoxWidth: React.PropTypes.number,
-    modal: React.PropTypes.bool,
-    movable: React.PropTypes.bool,
-    preview: React.PropTypes.string,
-    restore: React.PropTypes.bool,
-    responsive: React.PropTypes.bool,
-    rotatable: React.PropTypes.bool,
-    scalable: React.PropTypes.bool,
-    toggleDragModeOnDblclick: React.PropTypes.bool,
-    viewMode: React.PropTypes.oneOf([0, 1, 2, 3]),
-    wheelZoomRation: React.PropTypes.number,
-    zoomable: React.PropTypes.bool,
-    zoomOnTouch: React.PropTypes.bool,
-    zoomOnWheel: React.PropTypes.bool,
+    aspectRatio: PropTypes.number,
+    autoCrop: PropTypes.bool,
+    autoCropArea: PropTypes.number,
+    background: PropTypes.bool,
+    center: PropTypes.bool,
+    checkCrossOrigin: PropTypes.bool,
+    checkOrientation: PropTypes.bool,
+    cropBoxMovable: PropTypes.bool,
+    cropBoxResizable: PropTypes.bool,
+    guides: PropTypes.bool,
+    highlight: PropTypes.bool,
+    minCanvasHeight: PropTypes.number,
+    minCanvasWidth: PropTypes.number,
+    minContainerHeight: PropTypes.number,
+    minContainerWidth: PropTypes.number,
+    minCropBoxHeight: PropTypes.number,
+    minCropBoxWidth: PropTypes.number,
+    modal: PropTypes.bool,
+    movable: PropTypes.bool,
+    preview: PropTypes.string,
+    restore: PropTypes.bool,
+    responsive: PropTypes.bool,
+    rotatable: PropTypes.bool,
+    scalable: PropTypes.bool,
+    toggleDragModeOnDblclick: PropTypes.bool,
+    viewMode: PropTypes.oneOf([0, 1, 2, 3]),
+    wheelZoomRation: PropTypes.number,
+    zoomable: PropTypes.bool,
+    zoomOnTouch: PropTypes.bool,
+    zoomOnWheel: PropTypes.bool,
 
     // CropperJS event callbacks
-    crop: React.PropTypes.func,
-    cropend: React.PropTypes.func,
-    cropmove: React.PropTypes.func,
-    cropstart: React.PropTypes.func,
-    ready: React.PropTypes.func,
-    zoom: React.PropTypes.func,
+    crop: PropTypes.func,
+    cropend: PropTypes.func,
+    cropmove: PropTypes.func,
+    cropstart: PropTypes.func,
+    ready: PropTypes.func,
+    zoom: PropTypes.func,
 
     // Variable props
-    canvasData: React.PropTypes.shape({
-      left: React.PropTypes.number,
-      top: React.PropTypes.number,
-      width: React.PropTypes.number,
-      height: React.PropTypes.number
+    canvasData: PropTypes.shape({
+      left: PropTypes.number,
+      top: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number
     }),
-    cropBoxData: React.PropTypes.shape({
-      left: React.PropTypes.number,
-      top: React.PropTypes.number,
-      width: React.PropTypes.number,
-      height: React.PropTypes.number
+    cropBoxData: PropTypes.shape({
+      left: PropTypes.number,
+      top: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number
     }),
-    data: React.PropTypes.shape({
-      x: React.PropTypes.number,
-      y: React.PropTypes.number,
-      width: React.PropTypes.number,
-      height: React.PropTypes.number,
-      rotate: React.PropTypes.number,
-      scaleX: React.PropTypes.number,
-      scaleY: React.PropTypes.number
+    data: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number,
+      rotate: PropTypes.number,
+      scaleX: PropTypes.number,
+      scaleY: PropTypes.number
     }),
-    dragMode: React.PropTypes.oneOf(['crop', 'move', 'none']),
-    enable: React.PropTypes.bool,
-    moveTo: React.PropTypes.arrayOf(React.PropTypes.number),
-    rotateTo: React.PropTypes.number,
-    scaleX: React.PropTypes.number,
-    scaleY: React.PropTypes.number,
-    style: React.PropTypes.object,
-    zoomTo: React.PropTypes.number,
+    dragMode: PropTypes.oneOf(['crop', 'move', 'none']),
+    enable: PropTypes.bool,
+    moveTo: PropTypes.arrayOf(PropTypes.number),
+    rotateTo: PropTypes.number,
+    scaleX: PropTypes.number,
+    scaleY: PropTypes.number,
+    style: PropTypes.object,
+    zoomTo: PropTypes.number,
 
     // Type of image and the quality of the image to return as a data URL
-    imgType: React.PropTypes.string,
-    imgQuality: React.PropTypes.number
-  },
+    imgType: PropTypes.string,
+    imgQuality: PropTypes.number
+  }
 
-  getDefaultProps() {
-    return {
-      alt: '',
-      canvasData: null,
-      cropBoxData: null,
-      crossOrigin: null,
-      data: null,
-      dragMode: 'crop',
-      enable: true,
-      imgType: 'image/jpeg',
-      imgQuality: 0.92,
-      rotateTo: 0,
-      scaleX: 1,
-      scaleY: 1,
-      src: null,
-      style: null,
-      zoomTo: 1
-    };
-  },
+  static defaultProps = {
+    alt: '',
+    canvasData: null,
+    cropBoxData: null,
+    crossOrigin: null,
+    data: null,
+    dragMode: 'crop',
+    enable: true,
+    imgType: 'image/jpeg',
+    imgQuality: 0.92,
+    rotateTo: 0,
+    scaleX: 1,
+    scaleY: 1,
+    src: null,
+    style: null,
+    zoomTo: 1
+  }
 
   componentDidMount() {
     let options = {}, prop;
@@ -122,7 +120,7 @@ const ReactCropperJS = React.createClass({
     }
 
     this.cropper = new Cropper(this.refs.img, options);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
@@ -180,7 +178,7 @@ const ReactCropperJS = React.createClass({
         this.disable();
       }
     }
-  },
+  }
 
   componentWillUnmount() {
     if (this.cropper) {
@@ -188,132 +186,132 @@ const ReactCropperJS = React.createClass({
       // such as resize are cleaned up and do not leak
       this.cropper.destroy();
     }
-  },
+  }
 
   getCroppedImgDataURL() {
     return this.getCroppedCanvas().toDataURL(
       this.props.imgType,
       this.props.imgQuality
     );
-  },
+  }
 
   // Event handlers
-  crop(event) {
+  crop = (event) => {
     this.props.crop(event, this.getCroppedImgDataURL());
-  },
+  }
 
-  cropend(event) {
+  cropend = (event) => {
     this.props.cropend(event, this.getCroppedImgDataURL());
-  },
+  }
 
-  cropmove(event) {
+  cropmove = (event) => {
     this.props.cropmove(event, this.getCroppedImgDataURL());
-  },
+  }
 
-  cropstart(event) {
+  cropstart = (event) => {
     this.props.cropstart(event, this.getCroppedImgDataURL());
-  },
+  }
 
-  ready(event) {
+  ready = (event) => {
     this.props.ready(event, this.getCroppedImgDataURL());
-  },
+  }
 
-  zoom(event) {
+  zoom = (event) => {
     this.props.zoom(event, this.getCroppedImgDataURL());
-  },
+  }
 
   // CropperJS wrapped functions
   move(offsetX, offsetY) {
     return this.cropper.move(offsetX, offsetY);
-  },
+  }
 
-  moveTo(x, y) {
+  moveTo = (x, y) => {
     return this.cropper.moveTo(x, y);
-  },
+  }
 
-  zoomTo(ratio) {
+  zoomTo = (ratio) => {
     return this.cropper.zoomTo(ratio);
-  },
+  }
 
-  rotate(degree) {
+  rotate = (degree) => {
     return this.cropper.rotate(degree);
-  },
+  }
 
-  rotateTo(degree) {
+  rotateTo = (degree) => {
     return this.cropper.rotateTo(degree);
-  },
+  }
 
-  enable() {
+  enable = () => {
     return this.cropper.enable();
-  },
+  }
 
-  disable() {
+  disable = () => {
     return this.cropper.disable();
-  },
+  }
 
-  reset() {
+  reset = () => {
     return this.cropper.reset();
-  },
+  }
 
-  clear() {
+  clear = () => {
     return this.cropper.clear();
-  },
+  }
 
-  replace(url) {
+  replace = (url) => {
     return this.cropper.replace(url);
-  },
+  }
 
-  scaleX(scaleX) {
+  scaleX = (scaleX) => {
     return this.cropper.scaleX(scaleX);
-  },
+  }
 
-  scaleY(scaleY) {
+  scaleY = (scaleY) => {
     return this.cropper.scaleY(scaleY);
-  },
+  }
 
-  getData(rounded) {
+  getData = (rounded) => {
     return this.cropper.getData(rounded);
-  },
+  }
 
-  setData(data) {
+  setData = (data) => {
     return this.cropper.setData(data);
-  },
+  }
 
-  getContainerData() {
+  getContainerData = () => {
     return this.cropper.getContainerData();
-  },
+  }
 
-  getImageData() {
+  getImageData = () => {
     return this.cropper.getImageData();
-  },
+  }
 
-  getCanvasData() {
+  getCanvasData = () => {
     return this.cropper.getCanvasData();
-  },
+  }
 
-  setCanvasData(data) {
+  setCanvasData = (data) => {
     return this.cropper.setCanvasData(data);
-  },
+  }
 
-  getCropBoxData() {
+  getCropBoxData = () => {
     return this.cropper.getCropBoxData();
-  },
+  }
 
-  setCropBoxData(data) {
+  setCropBoxData = (data) => {
     return this.cropper.setCropBoxData(data);
-  },
+  }
 
-  getCroppedCanvas(options) {
+  getCroppedCanvas = (options) => {
     return this.cropper.getCroppedCanvas(options);
-  },
+  }
 
-  setAspectRatio(aspectRatio) {
+  setAspectRatio = (aspectRatio) => {
     return this.cropper.setAspectRatio(aspectRatio);
-  },
+  }
 
-  setDragMode(dragMode) {
+  setDragMode = (dragMode) => {
     return this.cropper.setDragMode(dragMode);
-  },
+  }
 
   render() {
     const imgStyle = {
@@ -336,6 +334,6 @@ const ReactCropperJS = React.createClass({
       </div>
     );
   }
-});
+}
 
 export default ReactCropperJS;


### PR DESCRIPTION
Converts the src/ReactCropperJS.jsx component to use ES6 class syntax
and updates the package.json with the repository, a needed babel plugin
and removes classnames since it is not used.